### PR TITLE
rename splitter to separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ yarn add react-resizable-layout
 import Resizable from 'react-resizable-layout';
 
 <Resizable axis={'x'}>
-  {({ position, splitterProps }) => (
+  {({ position, separatorProps }) => (
     <div className="wrapper">
       <div className="left-block" style={{ width: position }} />
-      <YourSplitterComponent {...splitterProps} />
+      <YourSeparatorComponent {...separatorProps} />
       <div className="right-block" />
     </div>
   )}
@@ -59,14 +59,14 @@ import Resizable from 'react-resizable-layout';
 import { useResizable } from 'react-resizable-layout';
 
 const Component = () => {
-  const { position, splitterProps } = useResizable({
+  const { position, separatorProps } = useResizable({
     axis: 'x',
   })
 
   return (
     <div className="wrapper">
       <div className="left-block" style={{ width: position }} />
-      <YourSplitterComponent {...splitterProps} />
+      <YourSeparatorComponent {...separatorProps} />
       <div className="right-block" />
     </div>
   )
@@ -94,24 +94,24 @@ const Component = () => {
 
 `useResizable` hook returns same.
 
-| Name          | Type    | Description                                                   |
-|---------------|---------|---------------------------------------------------------------|
-| position      | number  | Splitter's position (Width for 'x' axis, height for 'y' axis) |
-| isDragging    | boolean | If dragging then true                                         |
-| splitterProps | object  | Splitter's props like onMouseDown                             |
+| Name           | Type    | Description                                                    |
+|----------------|---------|----------------------------------------------------------------|
+| position       | number  | Separator's position (Width for 'x' axis, height for 'y' axis) |
+| isDragging     | boolean | If dragging then true                                          |
+| separatorProps | object  | Separator's props like onMouseDown                             |
 
 ## About keyboard support
 The following keyboard operations are supported.
 
-| Key                               | Operation                                  |
-|-----------------------------------|--------------------------------------------|
-| Arrow (`↑`,`→`,`↓`,`←`)           | Move the splitter by 10px (default)        |
-| `Shift` + Arrow (`↑`,`→`,`↓`,`←`) | Move the splitter by 50px (default)        |
-| `Enter`                           | Reset the splitter to the initial position |
+| Key                               | Operation                                   |
+|-----------------------------------|---------------------------------------------|
+| Arrow (`↑`,`→`,`↓`,`←`)           | Move the separator by 10px (default)        |
+| `Shift` + Arrow (`↑`,`→`,`↓`,`←`) | Move the separator by 50px (default)        |
+| `Enter`                           | Reset the separator to the initial position |
 
 
 ## About mouse support
-Double-click on the splitter to return it to its initial position.
+Double-click on the separator to return it to its initial position.
 
 ## Contribution
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,11 @@
 import type React from 'react';
 
-export type SplitterProps = React.ComponentPropsWithoutRef<'hr'>;
+export type SeparatorProps = React.ComponentPropsWithoutRef<'hr'>;
+
+/**
+ * @deprecated Use SeparatorProps instead
+ */
+export type SplitterProps = SeparatorProps;
 
 export type Resizable = {
   /**
@@ -13,6 +18,10 @@ export type Resizable = {
   isDragging: boolean;
   /**
    * props for drag bar
+   */
+  separatorProps: SeparatorProps;
+  /**
+   * @deprecated Use separatorProps instead
    */
   splitterProps: SplitterProps;
 };

--- a/src/useResizable.ts
+++ b/src/useResizable.ts
@@ -3,7 +3,7 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { KEYS_AXIS_X, KEYS_AXIS_Y, KEYS_POSITIVE } from './constants';
 
-import type { Resizable, SplitterProps, UseResizableProps } from './types';
+import type { Resizable, SeparatorProps, UseResizableProps } from './types';
 
 const useResizable = ({
   axis,
@@ -21,7 +21,7 @@ const useResizable = ({
   const [isDragging, setIsDragging] = useState(false);
   const [position, setPosition] = useState(Math.min(Math.max(initial, min), max));
 
-  const ariaProps = useMemo<SplitterProps>(
+  const ariaProps = useMemo<SeparatorProps>(
     () => ({
       role: 'separator',
       'aria-valuenow': position,
@@ -129,6 +129,13 @@ const useResizable = ({
   return {
     position,
     isDragging,
+    separatorProps: {
+      ...ariaProps,
+      onMouseDown: handleMousedown,
+      onKeyDown: handleKeyDown,
+      onDoubleClick: handleDoubleClick,
+    },
+    // deprecated. next version will remove this.
     splitterProps: {
       ...ariaProps,
       onMouseDown: handleMousedown,

--- a/stories/AxisX.stories.tsx
+++ b/stories/AxisX.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Resizable from '../src/Resizable';
 import SampleBox from './components/SampleBox';
-import SampleSplitter from './components/SampleSplitter';
+import SampleSeparator from './components/SampleSeparator';
 
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
@@ -13,10 +13,10 @@ export default {
 
 const Template: ComponentStory<typeof Resizable> = (props) => (
   <Resizable {...props}>
-    {({ position: x, splitterProps }) => (
+    {({ position: x, separatorProps }) => (
       <div id="wrapper" style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
         <SampleBox id="left-block" theme="blue" width={x} size={x} />
-        <SampleSplitter id="splitter" {...splitterProps} />
+        <SampleSeparator id="splitter" {...separatorProps} />
         <SampleBox id="right-block" theme="red" width={`calc(100% - ${x}px)`} />
       </div>
     )}

--- a/stories/AxisXReverse.stories.tsx
+++ b/stories/AxisXReverse.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Resizable from '../src/Resizable';
 import SampleBox from './components/SampleBox';
-import SampleSplitter from './components/SampleSplitter';
+import SampleSeparator from './components/SampleSeparator';
 
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
@@ -13,10 +13,10 @@ export default {
 
 const Template: ComponentStory<typeof Resizable> = (props) => (
   <Resizable {...props}>
-    {({ position: x, splitterProps }) => (
+    {({ position: x, separatorProps }) => (
       <div style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
         <SampleBox id="left-block" theme="blue" width={`calc(100% - ${x}px)`} />
-        <SampleSplitter id="splitter" {...splitterProps} />
+        <SampleSeparator id="splitter" {...separatorProps} />
         <SampleBox id="right-block" theme="red" width={x} size={x} />
       </div>
     )}

--- a/stories/AxisY.stories.tsx
+++ b/stories/AxisY.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Resizable from '../src/Resizable';
 import SampleBox from './components/SampleBox';
-import SampleSplitter from './components/SampleSplitter';
+import SampleSeparator from './components/SampleSeparator';
 
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
@@ -13,7 +13,7 @@ export default {
 
 const Template: ComponentStory<typeof Resizable> = (props) => (
   <Resizable {...props}>
-    {({ position: y, splitterProps }) => (
+    {({ position: y, separatorProps }) => (
       <div
         style={{
           display: 'flex',
@@ -23,7 +23,7 @@ const Template: ComponentStory<typeof Resizable> = (props) => (
         }}
       >
         <SampleBox id="top-block" height={y} theme="blue" size={y} />
-        <SampleSplitter id="splitter" dir="horizontal" {...splitterProps} />
+        <SampleSeparator id="splitter" dir="horizontal" {...separatorProps} />
         <SampleBox id="bottom-block" height={`calc(100% - ${y}px)`} theme="red" />
       </div>
     )}

--- a/stories/AxisYReverse.stories.tsx
+++ b/stories/AxisYReverse.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Resizable from '../src/Resizable';
 import SampleBox from './components/SampleBox';
-import SampleSplitter from './components/SampleSplitter';
+import SampleSeparator from './components/SampleSeparator';
 
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
@@ -13,7 +13,7 @@ export default {
 
 const Template: ComponentStory<typeof Resizable> = (props) => (
   <Resizable {...props}>
-    {({ position: y, splitterProps }) => (
+    {({ position: y, separatorProps }) => (
       <div
         style={{
           display: 'flex',
@@ -23,7 +23,7 @@ const Template: ComponentStory<typeof Resizable> = (props) => (
         }}
       >
         <SampleBox id="top-block" height={`calc(100% - ${y}px)`} theme="blue" />
-        <SampleSplitter id="splitter" dir="horizontal" {...splitterProps} />
+        <SampleSeparator id="splitter" dir="horizontal" {...separatorProps} />
         <SampleBox id="bottom-block" height={y} theme="red" size={y} />
       </div>
     )}

--- a/stories/Callback.stories.tsx
+++ b/stories/Callback.stories.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import Resizable from '../src/Resizable';
 import SampleBox from './components/SampleBox';
-import SampleSplitter from './components/SampleSplitter';
+import SampleSeparator from './components/SampleSeparator';
 
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
@@ -20,7 +20,7 @@ const Template: ComponentStory<typeof Resizable> = (props) => {
       onResizeStart={() => setDate(new Date())}
       onResizeEnd={() => alert(`You dragged!`)}
     >
-      {({ position: x, splitterProps }) => (
+      {({ position: x, separatorProps }) => (
         <div style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
           <SampleBox
             id="left-block"
@@ -29,7 +29,7 @@ const Template: ComponentStory<typeof Resizable> = (props) => {
             size={x}
             text={date && `dragging from ${date.toISOString()}`}
           />
-          <SampleSplitter id="splitter" {...splitterProps} />
+          <SampleSeparator id="splitter" {...separatorProps} />
           <SampleBox
             id="right-block"
             theme="red"

--- a/stories/Disabled.stories.tsx
+++ b/stories/Disabled.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Resizable from '../src/Resizable';
 import SampleBox from './components/SampleBox';
-import SampleSplitter from './components/SampleSplitter';
+import SampleSeparator from './components/SampleSeparator';
 
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
@@ -13,10 +13,10 @@ export default {
 
 const Template: ComponentStory<typeof Resizable> = (props) => (
   <Resizable {...props}>
-    {({ position: x, splitterProps }) => (
+    {({ position: x, separatorProps }) => (
       <div id="wrapper" style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
         <SampleBox id="left-block" theme="blue" width={x} size={x} />
-        <SampleSplitter id="splitter" disabled {...splitterProps} />
+        <SampleSeparator id="splitter" disabled {...separatorProps} />
         <SampleBox id="right-block" theme="red" width={`calc(100% - ${x}px)`} />
       </div>
     )}

--- a/stories/DraggingState.stories.tsx
+++ b/stories/DraggingState.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Resizable from '../src/Resizable';
 import SampleBox from './components/SampleBox';
-import SampleSplitter from './components/SampleSplitter';
+import SampleSeparator from './components/SampleSeparator';
 
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
@@ -13,7 +13,7 @@ export default {
 
 const Template: ComponentStory<typeof Resizable> = (props) => (
   <Resizable {...props}>
-    {({ position: x, isDragging, splitterProps }) => (
+    {({ position: x, isDragging, separatorProps }) => (
       <div style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
         <SampleBox
           id="left-block"
@@ -22,7 +22,7 @@ const Template: ComponentStory<typeof Resizable> = (props) => (
           size={x}
           text={isDragging && 'Dragging...'}
         />
-        <SampleSplitter id="splitter" {...splitterProps} />
+        <SampleSeparator id="splitter" {...separatorProps} />
         <SampleBox
           id="right-block"
           theme="red"

--- a/stories/components/IdeClone.tsx
+++ b/stories/components/IdeClone.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 
 import { useResizable } from '../../src';
 import { cn } from '../utils/cn';
-import SampleSplitter from './SampleSplitter';
+import SampleSeparator from './SampleSeparator';
 
 const IdeClone = (): JSX.Element => {
   const {
     isDragging: isTerminalDragging,
     position: terminalH,
-    splitterProps: terminalDragBarProps,
+    separatorProps: terminalDragBarProps,
   } = useResizable({
     axis: 'y',
     initial: 150,
@@ -18,7 +18,7 @@ const IdeClone = (): JSX.Element => {
   const {
     isDragging: isFileDragging,
     position: fileW,
-    splitterProps: fileDragBarProps,
+    separatorProps: fileDragBarProps,
   } = useResizable({
     axis: 'x',
     initial: 250,
@@ -27,7 +27,7 @@ const IdeClone = (): JSX.Element => {
   const {
     isDragging: isPluginDragging,
     position: pluginW,
-    splitterProps: pluginDragBarProps,
+    separatorProps: pluginDragBarProps,
   } = useResizable({
     axis: 'x',
     initial: 200,
@@ -44,10 +44,10 @@ const IdeClone = (): JSX.Element => {
         >
           File Tree
         </div>
-        <SampleSplitter isDragging={isFileDragging} {...fileDragBarProps} />
+        <SampleSeparator isDragging={isFileDragging} {...fileDragBarProps} />
         <div className="flex grow">
           <div className="grow bg-darker contents">Editor</div>
-          <SampleSplitter isDragging={isPluginDragging} {...pluginDragBarProps} />
+          <SampleSeparator isDragging={isPluginDragging} {...pluginDragBarProps} />
           <div
             className={cn('shrink-0 contents', isPluginDragging && 'dragging')}
             style={{ width: pluginW }}
@@ -56,11 +56,7 @@ const IdeClone = (): JSX.Element => {
           </div>
         </div>
       </div>
-      <SampleSplitter
-        dir="horizontal"
-        isDragging={isTerminalDragging}
-        {...terminalDragBarProps}
-      />
+      <SampleSeparator dir="horizontal" isDragging={isTerminalDragging} {...terminalDragBarProps} />
       <div
         className={cn('shrink-0 bg-darker contents', isTerminalDragging && 'dragging')}
         style={{ height: terminalH }}

--- a/stories/components/SampleSeparator.tsx
+++ b/stories/components/SampleSeparator.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import { cn } from '../utils/cn';
 
-const SampleSplitter = ({ id = 'drag-bar', dir, isDragging, disabled, ...props }: any) => {
+const SampleSeparator = ({ id = 'drag-bar', dir, isDragging, disabled, ...props }: any) => {
   const [isFocused, setIsFocused] = useState(false);
 
   return (
@@ -23,4 +23,4 @@ const SampleSplitter = ({ id = 'drag-bar', dir, isDragging, disabled, ...props }
   );
 };
 
-export default SampleSplitter;
+export default SampleSeparator;


### PR DESCRIPTION
Renamed splitter to separator to unify with aria role.

cf. https://www.w3.org/TR/wai-aria-1.2/#separator

Right now splitterProps still exists, but will be removed in the next version. (Deprecated)