### PR TITLE
Move to `PointerEvent`s to support touch screens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "react-resizable-layout",
+  "name": "react-resizable-layout-mobile",
   "description": "Lightweight, accessible headless React component and hook for drag-and-drop resizable layouts.",
   "author": "RyoSogawa",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -81,5 +81,6 @@
       "eslint --fix",
       "prettier --write"
     ]
-  }
+  },
+  "dependencies": {}
 }

--- a/src/useResizable.ts
+++ b/src/useResizable.ts
@@ -34,8 +34,8 @@ const useResizable = ({
     [axis, disabled, max, min, position],
   );
 
-  const handleMousemove = useCallback(
-    (e: MouseEvent) => {
+  const handlePointermove = useCallback(
+    (e: PointerEvent) => {
       // exit if not resizing
       if (!isResizing.current) return;
 
@@ -68,32 +68,32 @@ const useResizable = ({
     [axis, disabled, max, min, reverse, containerRef],
   );
 
-  const handleMouseup = useCallback(
+  const handlePointerup = useCallback(
     (e: MouseEvent) => {
       if (disabled) return;
 
       e.stopPropagation();
       isResizing.current = false;
       setIsDragging(false);
-      document.removeEventListener('mousemove', handleMousemove);
-      document.removeEventListener('mouseup', handleMouseup);
+      document.removeEventListener('pointermove', handlePointermove);
+      document.removeEventListener('pointerup', handlePointerup);
       if (onResizeEnd) onResizeEnd();
     },
-    [disabled, handleMousemove, onResizeEnd],
+    [disabled, handlePointermove, onResizeEnd],
   );
 
-  const handleMousedown = useCallback<React.MouseEventHandler>(
+  const handlePointerdown = useCallback<React.PointerEventHandler>(
     (e) => {
       if (disabled) return;
 
       e.stopPropagation();
       isResizing.current = true;
       setIsDragging(true);
-      document.addEventListener('mousemove', handleMousemove);
-      document.addEventListener('mouseup', handleMouseup);
+      document.addEventListener('pointermove', handlePointermove);
+      document.addEventListener('pointerup', handlePointerup);
       if (onResizeStart) onResizeStart();
     },
-    [disabled, handleMousemove, handleMouseup, onResizeStart],
+    [disabled, handlePointermove, handlePointerup, onResizeStart],
   );
 
   const handleKeyDown = useCallback<React.KeyboardEventHandler>(
@@ -142,14 +142,14 @@ const useResizable = ({
     isDragging,
     separatorProps: {
       ...ariaProps,
-      onMouseDown: handleMousedown,
+      onPointerDown: handlePointerdown,
       onKeyDown: handleKeyDown,
       onDoubleClick: handleDoubleClick,
     },
     // deprecated. next version will remove this.
     splitterProps: {
       ...ariaProps,
-      onMouseDown: handleMousedown,
+      onPointerDown: handlePointerdown,
       onKeyDown: handleKeyDown,
       onDoubleClick: handleDoubleClick,
     },


### PR DESCRIPTION
This package is otherwise awesome, but it lacks support for pointing devices other than mice. As the PointerEvent API is supported  [practically everywhere](https://caniuse.com/mdn-api_pointerevent), it's possible to use it as a direct, drop-in replacement for `MouseEvent`.

This commit includes all the necessary changes to implement the change. I have tested the implementation with my phone (touch) and computer (mouse).