### PR TITLE
feat: fixedPosition api

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ https://www.w3.org/TR/wai-aria-1.2/#separator
 | Name           | Type    | Description                                                    |
 |----------------|---------|----------------------------------------------------------------|
 | position       | number  | Separator's position (Width for 'x' axis, height for 'y' axis) |
+| fixedPosition  | number  | Position at start and end of drag                              |
 | isDragging     | boolean | If dragging then true                                          |
 | separatorProps | object  | Separator's props like onPointerDown                           |
   

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,10 @@ export type Resizable = {
    */
   position: number;
   /**
+   * position at start and end of drag
+   */
+  fixedPosition: number;
+  /**
    * whether the border is dragging
    */
   isDragging: boolean;

--- a/src/useResizable.ts
+++ b/src/useResizable.ts
@@ -107,6 +107,7 @@ const useResizable = ({
 
       if (e.key === 'Enter') {
         setPosition(initial);
+        positionRef.current = initial;
         return;
       }
       if (
@@ -125,10 +126,13 @@ const useResizable = ({
       const newPosition = position + changeStep * dir;
       if (newPosition < min) {
         setPosition(min);
+        positionRef.current = min;
       } else if (newPosition > max) {
         setPosition(max);
+        positionRef.current = max;
       } else {
         setPosition(newPosition);
+        positionRef.current = newPosition;
       }
 
       if (onResizeEnd) onResizeEnd();
@@ -140,6 +144,7 @@ const useResizable = ({
   const handleDoubleClick = useCallback<React.MouseEventHandler>(() => {
     if (disabled) return;
     setPosition(initial);
+    positionRef.current = initial;
   }, [disabled, initial]);
 
   return {

--- a/src/useResizable.ts
+++ b/src/useResizable.ts
@@ -18,9 +18,12 @@ const useResizable = ({
   onResizeEnd,
   containerRef,
 }: UseResizableProps): Resizable => {
+  const initialPosition = Math.min(Math.max(initial, min), max);
   const isResizing = useRef(false);
   const [isDragging, setIsDragging] = useState(false);
-  const [position, setPosition] = useState(Math.min(Math.max(initial, min), max));
+  const [position, setPosition] = useState(initialPosition);
+  const positionRef = useRef(initialPosition);
+  const [fixedPosition, setFixedPosition] = useState(initialPosition);
 
   const ariaProps = useMemo<SeparatorProps>(
     () => ({
@@ -63,6 +66,7 @@ const useResizable = ({
 
       if (min < currentPosition && currentPosition < max) {
         setPosition(currentPosition);
+        positionRef.current = currentPosition;
       }
     },
     [axis, disabled, max, min, reverse, containerRef],
@@ -75,6 +79,7 @@ const useResizable = ({
       e.stopPropagation();
       isResizing.current = false;
       setIsDragging(false);
+      setFixedPosition(positionRef.current);
       document.removeEventListener('pointermove', handlePointermove);
       document.removeEventListener('pointerup', handlePointerup);
       if (onResizeEnd) onResizeEnd();
@@ -139,6 +144,7 @@ const useResizable = ({
 
   return {
     position,
+    fixedPosition,
     isDragging,
     separatorProps: {
       ...ariaProps,

--- a/stories/AxisX.stories.tsx
+++ b/stories/AxisX.stories.tsx
@@ -7,7 +7,7 @@ import Resizable from '../src/Resizable';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 export default {
-  title: 'main/Basic',
+  title: 'Basic',
   component: Resizable,
 } as ComponentMeta<typeof Resizable>;
 

--- a/stories/AxisX.stories.tsx
+++ b/stories/AxisX.stories.tsx
@@ -7,7 +7,7 @@ import Resizable from '../src/Resizable';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 export default {
-  title: 'main/Resizable',
+  title: 'main/Basic',
   component: Resizable,
 } as ComponentMeta<typeof Resizable>;
 

--- a/stories/AxisXReverse.stories.tsx
+++ b/stories/AxisXReverse.stories.tsx
@@ -7,7 +7,7 @@ import Resizable from '../src/Resizable';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 export default {
-  title: 'main/Basic',
+  title: 'Basic',
   component: Resizable,
 } as ComponentMeta<typeof Resizable>;
 

--- a/stories/AxisXReverse.stories.tsx
+++ b/stories/AxisXReverse.stories.tsx
@@ -7,7 +7,7 @@ import Resizable from '../src/Resizable';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 export default {
-  title: 'main/Resizable',
+  title: 'main/Basic',
   component: Resizable,
 } as ComponentMeta<typeof Resizable>;
 

--- a/stories/AxisXReverseWithContainer.stories.tsx
+++ b/stories/AxisXReverseWithContainer.stories.tsx
@@ -7,7 +7,7 @@ import Resizable from '../src/Resizable';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 export default {
-  title: 'main/WithContainer',
+  title: 'WithContainer',
   component: Resizable,
 } as ComponentMeta<typeof Resizable>;
 

--- a/stories/AxisXReverseWithContainer.stories.tsx
+++ b/stories/AxisXReverseWithContainer.stories.tsx
@@ -7,7 +7,7 @@ import Resizable from '../src/Resizable';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 export default {
-  title: 'main/Resizable',
+  title: 'main/WithContainer',
   component: Resizable,
 } as ComponentMeta<typeof Resizable>;
 

--- a/stories/AxisXWithContainer.stories.tsx
+++ b/stories/AxisXWithContainer.stories.tsx
@@ -7,7 +7,7 @@ import Resizable from '../src/Resizable';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 export default {
-  title: 'main/WithContainer',
+  title: 'WithContainer',
   component: Resizable,
 } as ComponentMeta<typeof Resizable>;
 

--- a/stories/AxisXWithContainer.stories.tsx
+++ b/stories/AxisXWithContainer.stories.tsx
@@ -7,7 +7,7 @@ import Resizable from '../src/Resizable';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 export default {
-  title: 'main/Resizable',
+  title: 'main/WithContainer',
   component: Resizable,
 } as ComponentMeta<typeof Resizable>;
 

--- a/stories/AxisY.stories.tsx
+++ b/stories/AxisY.stories.tsx
@@ -7,7 +7,7 @@ import Resizable from '../src/Resizable';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 export default {
-  title: 'main/Basic',
+  title: 'Basic',
   component: Resizable,
 } as ComponentMeta<typeof Resizable>;
 

--- a/stories/AxisY.stories.tsx
+++ b/stories/AxisY.stories.tsx
@@ -7,7 +7,7 @@ import Resizable from '../src/Resizable';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 export default {
-  title: 'main/Resizable',
+  title: 'main/Basic',
   component: Resizable,
 } as ComponentMeta<typeof Resizable>;
 

--- a/stories/AxisYReverse.stories.tsx
+++ b/stories/AxisYReverse.stories.tsx
@@ -7,7 +7,7 @@ import Resizable from '../src/Resizable';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 export default {
-  title: 'main/Basic',
+  title: 'Basic',
   component: Resizable,
 } as ComponentMeta<typeof Resizable>;
 

--- a/stories/AxisYReverse.stories.tsx
+++ b/stories/AxisYReverse.stories.tsx
@@ -7,7 +7,7 @@ import Resizable from '../src/Resizable';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 export default {
-  title: 'main/Resizable',
+  title: 'main/Basic',
   component: Resizable,
 } as ComponentMeta<typeof Resizable>;
 

--- a/stories/AxisYReverseWithContainer.stories.tsx
+++ b/stories/AxisYReverseWithContainer.stories.tsx
@@ -7,7 +7,7 @@ import Resizable from '../src/Resizable';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 export default {
-  title: 'main/WithContainer',
+  title: 'WithContainer',
   component: Resizable,
 } as ComponentMeta<typeof Resizable>;
 

--- a/stories/AxisYReverseWithContainer.stories.tsx
+++ b/stories/AxisYReverseWithContainer.stories.tsx
@@ -7,7 +7,7 @@ import Resizable from '../src/Resizable';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 export default {
-  title: 'main/Resizable',
+  title: 'main/WithContainer',
   component: Resizable,
 } as ComponentMeta<typeof Resizable>;
 

--- a/stories/AxisYWithContainer.stories.tsx
+++ b/stories/AxisYWithContainer.stories.tsx
@@ -7,7 +7,7 @@ import Resizable from '../src/Resizable';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 export default {
-  title: 'main/WithContainer',
+  title: 'WithContainer',
   component: Resizable,
 } as ComponentMeta<typeof Resizable>;
 

--- a/stories/AxisYWithContainer.stories.tsx
+++ b/stories/AxisYWithContainer.stories.tsx
@@ -7,7 +7,7 @@ import Resizable from '../src/Resizable';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 export default {
-  title: 'main/Resizable',
+  title: 'main/WithContainer',
   component: Resizable,
 } as ComponentMeta<typeof Resizable>;
 

--- a/stories/Callback.stories.tsx
+++ b/stories/Callback.stories.tsx
@@ -7,7 +7,7 @@ import Resizable from '../src/Resizable';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 export default {
-  title: 'main/Advanced',
+  title: 'Advanced',
   component: Resizable,
 } as ComponentMeta<typeof Resizable>;
 

--- a/stories/Callback.stories.tsx
+++ b/stories/Callback.stories.tsx
@@ -7,7 +7,7 @@ import Resizable from '../src/Resizable';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 export default {
-  title: 'main/Resizable',
+  title: 'main/Advanced',
   component: Resizable,
 } as ComponentMeta<typeof Resizable>;
 

--- a/stories/Disabled.stories.tsx
+++ b/stories/Disabled.stories.tsx
@@ -7,7 +7,7 @@ import Resizable from '../src/Resizable';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 export default {
-  title: 'main/Basic',
+  title: 'Basic',
   component: Resizable,
 } as ComponentMeta<typeof Resizable>;
 

--- a/stories/Disabled.stories.tsx
+++ b/stories/Disabled.stories.tsx
@@ -7,7 +7,7 @@ import Resizable from '../src/Resizable';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 export default {
-  title: 'main/Resizable',
+  title: 'main/Basic',
   component: Resizable,
 } as ComponentMeta<typeof Resizable>;
 

--- a/stories/DraggingState.stories.tsx
+++ b/stories/DraggingState.stories.tsx
@@ -7,7 +7,7 @@ import Resizable from '../src/Resizable';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 export default {
-  title: 'main/Advanced',
+  title: 'Advanced',
   component: Resizable,
 } as ComponentMeta<typeof Resizable>;
 

--- a/stories/DraggingState.stories.tsx
+++ b/stories/DraggingState.stories.tsx
@@ -7,7 +7,7 @@ import Resizable from '../src/Resizable';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 export default {
-  title: 'main/Resizable',
+  title: 'main/Advanced',
   component: Resizable,
 } as ComponentMeta<typeof Resizable>;
 

--- a/stories/IdeClone.stories.tsx
+++ b/stories/IdeClone.stories.tsx
@@ -5,11 +5,11 @@ import IdeClone from './components/IdeClone';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 export default {
-  title: 'sample/clone',
+  title: 'Example',
   component: IdeClone,
 } as ComponentMeta<typeof IdeClone>;
 
 const Template: ComponentStory<typeof IdeClone> = () => <IdeClone />;
 
-export const IDE = Template.bind({});
-IDE.args = {};
+export const IDEClone = Template.bind({});
+IDEClone.args = {};

--- a/stories/VirtualSplitter.stories.tsx
+++ b/stories/VirtualSplitter.stories.tsx
@@ -24,9 +24,9 @@ const Template: ComponentStory<typeof Resizable> = (props) => (
         }}
       >
         <SampleBox id="left-block" theme="blue" width={fixedX} size={fixedX} />
-        <SampleSeparator id="splitter" {...separatorProps} />
+        <SampleSeparator id="splitter" />
         <SampleSeparator
-          id="splitter"
+          id="virtual-splitter"
           {...separatorProps}
           style={{
             position: 'absolute',

--- a/stories/VirtualSplitter.stories.tsx
+++ b/stories/VirtualSplitter.stories.tsx
@@ -7,7 +7,7 @@ import Resizable from '../src/Resizable';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 export default {
-  title: 'main/Advanced',
+  title: 'Advanced',
   component: Resizable,
 } as ComponentMeta<typeof Resizable>;
 

--- a/stories/VirtualSplitter.stories.tsx
+++ b/stories/VirtualSplitter.stories.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import SampleBox from './components/SampleBox';
+import SampleSeparator from './components/SampleSeparator';
+import Resizable from '../src/Resizable';
+
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+
+export default {
+  title: 'main/Resizable',
+  component: Resizable,
+} as ComponentMeta<typeof Resizable>;
+
+const Template: ComponentStory<typeof Resizable> = (props) => (
+  <Resizable {...props}>
+    {({ position: x, fixedPosition: fixedX, isDragging, separatorProps }) => (
+      <div
+        id="wrapper"
+        style={{
+          position: 'relative',
+          display: 'flex',
+          height: '100vh',
+          overflow: 'hidden',
+        }}
+      >
+        <SampleBox id="left-block" theme="blue" width={fixedX} size={fixedX} />
+        <SampleSeparator id="splitter" {...separatorProps} />
+        <SampleSeparator
+          id="splitter"
+          {...separatorProps}
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: x,
+            height: '100%',
+            opacity: isDragging ? 0.3 : 0,
+          }}
+        />
+        <SampleBox id="right-block" theme="red" width={`calc(100% - ${fixedX}px)`} />
+      </div>
+    )}
+  </Resizable>
+);
+
+export const VirtualSplitter = Template.bind({});
+VirtualSplitter.args = {
+  axis: 'x',
+  initial: 200,
+  min: 100,
+  max: 500,
+};

--- a/stories/VirtualSplitter.stories.tsx
+++ b/stories/VirtualSplitter.stories.tsx
@@ -7,7 +7,7 @@ import Resizable from '../src/Resizable';
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 export default {
-  title: 'main/Resizable',
+  title: 'main/Advanced',
   component: Resizable,
 } as ComponentMeta<typeof Resizable>;
 


### PR DESCRIPTION
The newly added `fixedPosition` API returns the position at which the DnD starts and ends.

By using this, it is now possible to implement a virtual splitter that does not update the actual layout until the end of the DnD.

<a href="https://gyazo.com/c26fd5080759791a0b769685ec8ac474"><img src="https://i.gyazo.com/c26fd5080759791a0b769685ec8ac474.gif" alt="Image from Gyazo" width="1000"/></a>

