### PR TITLE
feat: expose setPosition

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,10 @@ export type Resizable = {
    */
   separatorProps: SeparatorProps;
   /**
+   * set border position
+   */
+  setPosition: React.Dispatch<React.SetStateAction<number>>;
+  /**
    * @deprecated Use separatorProps instead
    */
   splitterProps: SplitterProps;

--- a/src/useResizable.ts
+++ b/src/useResizable.ts
@@ -157,6 +157,7 @@ const useResizable = ({
       onKeyDown: handleKeyDown,
       onDoubleClick: handleDoubleClick,
     },
+    setPosition,
     // deprecated. next version will remove this.
     splitterProps: {
       ...ariaProps,


### PR DESCRIPTION
Enable external programmatic control of the border position.

This is useful in the scenario which the resizable panels are within a resizable container and when the container shrinks the panels can also be resized smaller to maintain minimum size of panels.