### PR TITLE
clamp the current position to the min/max

### DIFF
--- a/src/useResizable.ts
+++ b/src/useResizable.ts
@@ -64,7 +64,7 @@ const useResizable = ({
         return reverse ? document.body.offsetHeight - e.clientY : e.clientY;
       })();
 
-      currentPosition = Math.max(Math.min(currentPosition, max), min);
+      currentPosition = Math.min(Math.max(currentPosition, min), max);
       setPosition(currentPosition);
       positionRef.current = currentPosition;
     },

--- a/src/useResizable.ts
+++ b/src/useResizable.ts
@@ -47,7 +47,7 @@ const useResizable = ({
       e.stopPropagation();
       e.preventDefault(); // prevent text selection
 
-      const currentPosition = (() => {
+      let currentPosition = (() => {
         if (axis === 'x') {
           if (containerRef?.current) {
             const containerNode = containerRef.current;

--- a/src/useResizable.ts
+++ b/src/useResizable.ts
@@ -64,10 +64,9 @@ const useResizable = ({
         return reverse ? document.body.offsetHeight - e.clientY : e.clientY;
       })();
 
-      if (min < currentPosition && currentPosition < max) {
-        setPosition(currentPosition);
-        positionRef.current = currentPosition;
-      }
+      currentPosition = Math.max(Math.min(currentPosition, max), min);
+      setPosition(currentPosition);
+      positionRef.current = currentPosition;
     },
     [axis, disabled, max, min, reverse, containerRef],
   );


### PR DESCRIPTION
When dragging quickly, the position might go beyond the min/max before the animation catches up. In this case the `handlePointerMove` callback will ignore updating the position, but incase a min/max is defined it should be set to the min or max as appropriate so the drag handle is guaranteed to hit the min/max position. 

I propose the following changes that are working for my test case, but welcome any suggestions. 

Thanks for the excellent package!