### PR TITLE
Fix: Prevent text selection during drag resize (Issue #38)

### DIFF
--- a/src/useResizable.ts
+++ b/src/useResizable.ts
@@ -91,6 +91,7 @@ const useResizable = ({
       if (disabled) return;
 
       e.stopPropagation();
+      e.preventDefault(); // prevent text selection
       isResizing.current = true;
       setIsDragging(true);
       document.addEventListener('pointermove', handlePointermove);


### PR DESCRIPTION
## Summary
- Fixed text selection issue during drag resize by adding `e.preventDefault()` to the `handlePointerdown` event handler
- Resolves #38

## Changes
- Added `e.preventDefault()` in the `handlePointerdown` function in `src/useResizable.ts`
- This prevents unwanted text selection when dragging the resize handle

## Test plan
- [x] Tested locally with Storybook
- [x] TypeScript type checking passes
- [x] ESLint passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)